### PR TITLE
Fix problem in compiling with Qt5.9 and later

### DIFF
--- a/radarscaneffect.cpp
+++ b/radarscaneffect.cpp
@@ -3,10 +3,11 @@
 #include <QDebug>
 #include <QOpenGLShaderProgram>
 #include <QSGSimpleTextureNode>
+#include <QOpenGLFunctions>
 
 #include "radarscaneffect.hpp"
 
-class TextureNode : public QObject, public QSGSimpleTextureNode
+class TextureNode : public QObject, public QSGSimpleTextureNode,public QOpenGLFunctions
 {
     Q_OBJECT
 


### PR DESCRIPTION
Fix problem in compiling with Qt 5.9 and later that occured because opengl and header and some opengl function.